### PR TITLE
Pass button arguments on

### DIFF
--- a/R/geoloc.R
+++ b/R/geoloc.R
@@ -54,7 +54,7 @@ button_geoloc <- function(inputId, label, icon = NULL, width = NULL, ...){
       )
     ),
     tagAppendAttributes(
-      actionButton(inputId, label, icon = NULL, width = NULL, ...),
+      actionButton(inputId, label, icon = icon, width = width, ...),
       onclick = "getLocation()"
     )
   )


### PR DESCRIPTION
`icon` and `width` arguments were not passed on from `button_geoloc()` to `shiny::actionButton()`, PR fixes this.