### PR TITLE
Allow for more than one geoloc_button

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,5 @@
+CODE_OF_CONDUCT.md
+LICENSE.md
+README.Rmd
+data-raw
+geoloc.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,10 @@
 Package: geoloc
 Title: Geolocation in Shiny
 Version: 0.0.0.9000
-Authors@R: person('Colin', 'Fay', email = 'contact@colinfay.me', role = c('cre', 'aut'))
+Authors@R: c(
+    person('Colin', 'Fay', email = 'contact@colinfay.me', role = c('cre', 'aut')),
+    person('John', 'Coene', email = 'jcoenep@gmail.com', role = 'ctb')
+    )
 Description: Add geolocation inside your shiny app.
 License: MIT + file LICENSE
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ Suggests:
 Imports: 
     attempt,
     shiny
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.99.9001

--- a/R/geoloc.R
+++ b/R/geoloc.R
@@ -46,6 +46,7 @@ onload_geoloc <- function(){
 #' @importFrom shiny tagList includeScript tagAppendAttributes actionButton
 
 button_geoloc <- function(inputId, label, icon = NULL, width = NULL, ...){
+  func <- paste0("getLocation(\"", inputId, "\")")
   tagList(
     includeScript(
       system.file(
@@ -55,7 +56,7 @@ button_geoloc <- function(inputId, label, icon = NULL, width = NULL, ...){
     ),
     tagAppendAttributes(
       actionButton(inputId, label, icon = icon, width = width, ...),
-      onclick = "getLocation()"
+      onclick = func
     )
   )
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,5 +1,7 @@
 ---
-output: github_document
+output: 
+  github_document:
+    html_preview: false
 ---
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -84,7 +86,7 @@ shinyApp(ui, server)
 
 ### With a button 
 
-`button_geoloc` behaves a any `shiny::actionButton` (and takes the same parameters), except that it launches the geolocation service when it is clicked.
+`button_geoloc` behaves like any `shiny::actionButton` (and takes the same parameters), except that it launches the geolocation service when it is clicked. You can then pick up the coordinates with `myButtonId_lat` and `myButtonId_lon`.
 
 ```{r eval = FALSE}
 library(shiny)
@@ -93,19 +95,19 @@ library(leaflet)
 ui <- fluidPage(
   h2("Where Am I?"),
   tags$p("Click the button to get your location"),
-  geoloc::button_geoloc("id", "Get my Location"),
+  geoloc::button_geoloc("myBtn", "Get my Location"),
   tags$br(),
   leafletOutput("lf")
 )
 
 server <- function(input, output) {
   output$lf <- renderLeaflet({
-    req(input$geoloc_lon)
-    req(input$geoloc_lat)
+    req(input$myBtn_lon)
+    req(input$myBtn_lat)
     leaflet() %>%
       addTiles() %>%
-      setView(as.numeric(input$geoloc_lon), as.numeric(input$geoloc_lat), zoom = 17) %>%
-      addMarkers(as.numeric(input$geoloc_lon), as.numeric(input$geoloc_lat), label = "You're here!")
+      setView(as.numeric(input$myBtn_lon), as.numeric(input$myBtn_lat), zoom = 17) %>%
+      addMarkers(as.numeric(input$myBtn_lon), as.numeric(input$myBtn_lat), label = "You're here!")
   })
 }
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ shinyApp(ui, server)
 
 ### With a button
 
-`button_geoloc` behaves a any `shiny::actionButton` (and takes the same
-parameters), except that it launches the geolocation service when it is
-clicked.
+`button_geoloc` behaves like any `shiny::actionButton` (and takes the
+same parameters), except that it launches the geolocation service when
+it is clicked. You can then pick up the coordinates with
+`myButtonId_lat` and `myButtonId_lon`.
 
 ``` r
 library(shiny)
@@ -92,19 +93,19 @@ library(leaflet)
 ui <- fluidPage(
   h2("Where Am I?"),
   tags$p("Click the button to get your location"),
-  geoloc::button_geoloc("id", "Get my Location"),
+  geoloc::button_geoloc("myBtn", "Get my Location"),
   tags$br(),
   leafletOutput("lf")
 )
 
 server <- function(input, output) {
   output$lf <- renderLeaflet({
-    req(input$geoloc_lon)
-    req(input$geoloc_lat)
+    req(input$myBtn_lon)
+    req(input$myBtn_lat)
     leaflet() %>%
       addTiles() %>%
-      setView(as.numeric(input$geoloc_lon), as.numeric(input$geoloc_lat), zoom = 17) %>%
-      addMarkers(as.numeric(input$geoloc_lon), as.numeric(input$geoloc_lat), label = "You're here!")
+      setView(as.numeric(input$myBtn_lon), as.numeric(input$myBtn_lat), zoom = 17) %>%
+      addMarkers(as.numeric(input$myBtn_lon), as.numeric(input$myBtn_lat), label = "You're here!")
   })
 }
 

--- a/inst/js/geoloc.js
+++ b/inst/js/geoloc.js
@@ -1,4 +1,30 @@
-function getLocation() {
+function getLocation(id = "geoloc") {
+
+  var lat_input = id  + "_lat";
+  var lon_input = id  + "_lon";
+
+  function sucess_pos(position) {
+    Shiny.onInputChange(lat_input, position.coords.latitude);
+    Shiny.onInputChange(lon_input, position.coords.longitude);
+  }
+
+  function error_pos(error) {
+    switch(error.code){
+        case error.PERMISSION_DENIED:
+            Shiny.onInputChange(lat_input, "PERMISSION_DENIED");
+            Shiny.onInputChange(lon_input, "PERMISSION_DENIED");
+            break;
+        case error.POSITION_UNAVAILABLE:
+            Shiny.onInputChange(lat_input, "POSITION_UNAVAILABLE");
+            Shiny.onInputChange(lon_input, "POSITION_UNAVAILABLE");
+            break;
+        case error.TIMEOUT:
+            Shiny.onInputChange(lat_input, "TIMEOUT");
+            Shiny.onInputChange(lon_input, "TIMEOUT");
+            break;
+        }
+}
+
   if (navigator.geolocation) {
   navigator.geolocation.getCurrentPosition(
     sucess_pos,
@@ -6,29 +32,8 @@ function getLocation() {
     {enableHighAccuracy:true, maximumAge:30000, timeout:27000});
   } else {
   alert("Geolocation is not supported by this browser.");
-  Shiny.onInputChange("geoloc_lat", "NOT_SUPPORTED");
-  Shiny.onInputChange("geoloc_lon", "NOT_SUPPORTED");
+  Shiny.onInputChange(id + "_lat", "NOT_SUPPORTED");
+  Shiny.onInputChange(id + "_lon", "NOT_SUPPORTED");
   }
 }
 
-function sucess_pos(position) {
-  Shiny.onInputChange("geoloc_lat", position.coords.latitude);
-  Shiny.onInputChange("geoloc_lon", position.coords.longitude);
-}
-
-function error_pos(error) {
-    switch(error.code){
-        case error.PERMISSION_DENIED:
-            Shiny.onInputChange("geoloc_lat", "PERMISSION_DENIED");
-            Shiny.onInputChange("geoloc_lon", "PERMISSION_DENIED");
-            break;
-        case error.POSITION_UNAVAILABLE:
-            Shiny.onInputChange("geoloc_lat", "POSITION_UNAVAILABLE");
-            Shiny.onInputChange("geoloc_lon", "POSITION_UNAVAILABLE");
-            break;
-        case error.TIMEOUT:
-            Shiny.onInputChange("geoloc_lat", "TIMEOUT");
-            Shiny.onInputChange("geoloc_lon", "TIMEOUT");
-            break;
-        }
-}

--- a/man/button_geoloc.Rd
+++ b/man/button_geoloc.Rd
@@ -12,10 +12,10 @@ button_geoloc(inputId, label, icon = NULL, width = NULL, ...)
 \item{label}{The contents of the button or link--usually a text label, but
 you could also use any other HTML, like an image.}
 
-\item{icon}{An optional \code{\link{icon}} to appear on the button.}
+\item{icon}{An optional \code{\link[=icon]{icon()}} to appear on the button.}
 
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
-see \code{\link{validateCssUnit}}.}
+see \code{\link[=validateCssUnit]{validateCssUnit()}}.}
 
 \item{...}{Named attributes to be applied to the button or link.}
 }


### PR DESCRIPTION
Hi Colin,

I have an app where I want more than one button so it's good to be able to distinguish between them. This PR allows this by passing the `inputId` to JavaScript. 

This however does break previous buttons unless their id was `geoloc`.

```r
library(shiny)
library(leaflet)

ui <- fluidPage(
  h2("Where Am I?"),
  tags$p("Click the button to get your location"),
  geoloc::button_geoloc("myBtn", "Get my Location"), # note the id
  tags$br(),
  leafletOutput("lf")
)

server <- function(input, output) {
  output$lf <- renderLeaflet({
    req(input$myBtn_lon) # use button id to fetch coordinates
    req(input$myBtn_lat)
    leaflet() %>%
      addTiles() %>%
      setView(as.numeric(input$myBtn_lon), as.numeric(input$myBtn_lat), zoom = 17) %>%
      addMarkers(as.numeric(input$myBtn_lon), as.numeric(input$myBtn_lat), label = "You're here!")
  })
}

shinyApp(ui, server)
```